### PR TITLE
Fail job if shellcheck reports and error

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -25,7 +25,7 @@ files=()
 # Evaluate all the globs and return the files that exist
 for file in $(plugin_read_list FILES) ; do
   if [[ -e $file ]] ; then
-    files+=("$file")
+    files+=("mnt/$file")
   fi
 done
 
@@ -37,4 +37,7 @@ fi
 echo "+++ Running shellcheck on ${#files[@]} files"
 if docker run --rm -v "$PWD:/mnt" koalaman/shellcheck "${files[@]}" ; then
   echo "Files are ok ✅"
+else
+  echo "shellcheck found errors"
+  exit 1
 fi


### PR DESCRIPTION
Return `1` as exit status if shellcheck finds errors. Also fixes volume path as shellcheck Docker image removed WORKDIR of `/mnt` in [6b81a9](https://github.com/koalaman/shellcheck/commit/6b81a9924c46836227ef9fc06e552ded17cd2383#diff-3254677a7917c6c01f55212f86c57fbf)