### PR TITLE
Passing options to shellcheck

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu -o pipefail
+set -eux -o pipefail
 
 # Reads either a value or a list from plugin config
 function plugin_read_list() {
@@ -41,7 +41,7 @@ if [[ -z ${files:-} ]] ; then
 fi
 
 echo "+++ Running shellcheck on ${#files[@]} files"
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" koalaman/shellcheck "${options[@]}" "${files[@]}" ; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" koalaman/shellcheck "${options[@]+${options[@]}}" "${files[@]}" ; then
   echo "Files are ok ✅"
 else
   exit 1

--- a/hooks/command
+++ b/hooks/command
@@ -21,6 +21,7 @@ function plugin_read_list() {
 
 IFS=$'\n\t'
 files=()
+options=()
 
 # Evaluate all the globs and return the files that exist
 for file in $(plugin_read_list FILES) ; do
@@ -29,13 +30,18 @@ for file in $(plugin_read_list FILES) ; do
   fi
 done
 
+# Read in the options to pass to shellcheck
+for option in $(plugin_read_list OPTIONS) ; do
+  options+=("$option")
+done
+
 if [[ -z ${files:-} ]] ; then
   echo "No files found to shellcheck"
   exit 1
 fi
 
 echo "+++ Running shellcheck on ${#files[@]} files"
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" koalaman/shellcheck "${files[@]}" ; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" koalaman/shellcheck "${options[@]}" "${files[@]}" ; then
   echo "Files are ok ✅"
 else
   exit 1

--- a/hooks/command
+++ b/hooks/command
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -eu -o pipefail
 
 # Reads either a value or a list from plugin config
 function plugin_read_list() {

--- a/hooks/command
+++ b/hooks/command
@@ -21,7 +21,6 @@ function plugin_read_list() {
 
 IFS=$'\n\t'
 files=()
-options=()
 
 # Evaluate all the globs and return the files that exist
 for file in $(plugin_read_list FILES) ; do
@@ -30,15 +29,13 @@ for file in $(plugin_read_list FILES) ; do
   fi
 done
 
-# Read in the options to pass to shellcheck
-for option in $(plugin_read_list OPTIONS) ; do
-  options+=("$option")
-done
-
 if [[ -z ${files:-} ]] ; then
   echo "No files found to shellcheck"
   exit 1
 fi
+
+# Read in the options to pass to shellcheck
+mapfile -t options<<<"$(plugin_read_list OPTIONS)"
 
 echo "+++ Running shellcheck on ${#files[@]} files"
 if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" koalaman/shellcheck "${options[@]+${options[@]}}" "${files[@]}" ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,5 +9,8 @@ configuration:
     files:
       type: [string, array]
       minItems: 1
+    options:
+      type: [string, array]
+      minItems: 1
   required:
     - files

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -34,6 +34,57 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
+@test "Shellcheck a single file with single option" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/subdir/llamas.sh"
+  export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_0="--exclude=SC2086"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck --exclude=SC2086 tests/testdata/subdir/llamas.sh : echo testing llamas.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "testing llamas.sh"
+
+  unstub docker
+}
+
+@test "Shellcheck a single file with multiple options" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/subdir/llamas.sh"
+  export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_0="--exclude=SC2086"
+  export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_1="--format=gcc"
+  export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_2="-x"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck --exclude=SC2086 --format=gcc -x tests/testdata/subdir/llamas.sh : echo testing llamas.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "testing llamas.sh"
+
+  unstub docker
+}
+
+@test "Shellcheck multiple files with multiple options" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/test.sh"
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_1="tests/testdata/subdir/*"
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_2="missing"
+  export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_0="--exclude=SC2086"
+  export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_1="--format=gcc"
+  export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_2="-x"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck --exclude=SC2086 --format=gcc -x tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell\ with\ space.sh' : echo testing test.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "testing test.sh"
+
+  unstub docker
+}
+
 @test "Shellcheck failure" {
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/subdir/llamas.sh"
 


### PR DESCRIPTION
This PR enables options to be passed to the shellcheck docker image, usage as such:

```
steps:
  - plugins:
      shellcheck#v1.0.1:
        files: scripts/*.sh
        options:
          - --exclude=SC2207,SC2154
          - --format=gcc
```

When making a release from this, please update the Readme to reflect this.