### PR TITLE
Make option parsing work in bash 3.x

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -35,7 +35,9 @@ if [[ -z ${files:-} ]] ; then
 fi
 
 # Read in the options to pass to shellcheck
-mapfile -t options<<<"$(plugin_read_list OPTIONS)"
+while IFS=$'\n' read -r option ; do
+  options+=("$option")
+done < <(plugin_read_list OPTIONS)
 
 echo "+++ Running shellcheck on ${#files[@]} files"
 if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" koalaman/shellcheck "${options[@]+${options[@]}}" "${files[@]}" ; then


### PR DESCRIPTION
A previous PR introduced `mapfile` calls which require bash 4.x. This uses read to tokenize options by line. 