### PR TITLE
document `options`, and pass --color=always by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ steps:
 
 The files (or globs) to run shellcheck on
 
+### `options`
+
+Any options to pass to shellcheck
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -34,7 +34,10 @@ if [[ -z ${files:-} ]] ; then
   exit 1
 fi
 
-# Read in the options to pass to shellcheck
+# Read in the options to pass to shellcheck.  Ask for color by default
+# for pretty online log display (but someone can override this with an
+# explicit `options: "--color=never"`)
+options=("--color=always")
 while IFS=$'\n' read -r option ; do
   options+=("$option")
 done < <(plugin_read_list OPTIONS)


### PR DESCRIPTION
Unfortunately, the color seems to be the main way that severity of a
message is communicated and so is moderately important. Someone can
override this with a later `--color=never` (i.e. `shellcheck
--color=always --color=never` doesn't emit any colours).
