### PR TITLE
Make shellcheck docker image version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Command line options to pass to shellcheck.
 
 Default: `"--color=always"`
 
+### `version` (string)
+
+Version of docker image to use.
+
+Default: `latest`
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,7 @@ while IFS=$'\n' read -r option ; do
   options+=("$option")
 done < <(plugin_read_list OPTIONS)
 
-VERSION="${VERSION:-latest}"
+BUILDKITE_PLUGIN_SHELLCHECK_VERSION="${BUILDKITE_PLUGIN_SHELLCHECK_VERSION:-stable}"
 
 echo "+++ Running shellcheck on ${#files[@]} files"
 if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "koalaman/shellcheck:$VERSION" "${options[@]+${options[@]}}" "${files[@]}" ; then

--- a/hooks/command
+++ b/hooks/command
@@ -42,8 +42,10 @@ while IFS=$'\n' read -r option ; do
   options+=("$option")
 done < <(plugin_read_list OPTIONS)
 
+VERSION="${VERSION:-latest}"
+
 echo "+++ Running shellcheck on ${#files[@]} files"
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" koalaman/shellcheck "${options[@]+${options[@]}}" "${files[@]}" ; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "koalaman/shellcheck:$VERSION" "${options[@]+${options[@]}}" "${files[@]}" ; then
   echo "Files are ok ✅"
 else
   exit 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,5 +12,7 @@ configuration:
     options:
       type: [string, array]
       minItems: 1
+    version:
+      type: [string]
   required:
     - files


### PR DESCRIPTION
Based on a recent build failure[1] for shellcheck, and to permit choice within versions I've included an optional flag to pin an image version.

[1] https://github.com/koalaman/shellcheck/issues/1751