### PR TITLE
Add support for extended and recursive globs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ The files (or globs) to run shellcheck on.
 
 Enable using [extended glob patterns](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html), e.g. `*.+(sh|bash)`
 
-Note: _requires at least Bash 4 on the Buildkite Agent_
-
 Default: `false`
 
 ### `globstar` (boolean)

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ The files (or globs) to run shellcheck on.
 
 ### Optional
 
-### `extglob` (boolean)
+### `extended_glob` (boolean)
 
 Enable using [extended glob patterns](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html), e.g. `*.+(sh|bash)`
 
 Default: `false`
 
-### `globstar` (boolean)
+### `recursive_glob` (boolean)
 
 Enable using recursive globbing, e.g. `**/*.sh`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ The files (or globs) to run shellcheck on.
 
 ### Optional
 
+### `extglob` (boolean)
+
+Enable using [extended glob patterns](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html), e.g. `*.+(sh|bash)`
+
+Note: _requires at least Bash 4 on the Buildkite Agent_
+
+Default: `false`
+
+### `extglob` (boolean)
+
+Enable using recursive globbing, e.g. `**/*.sh`
+
+Note: _requires at least Bash 4 on the Buildkite Agent_
+
+Default: `false`
+
 ### `options` (string or array of strings)
 
 Command line options to pass to shellcheck.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note: _requires at least Bash 4 on the Buildkite Agent_
 
 Default: `false`
 
-### `extglob` (boolean)
+### `globstar` (boolean)
 
 Enable using recursive globbing, e.g. `**/*.sh`
 

--- a/hooks/command
+++ b/hooks/command
@@ -12,7 +12,7 @@ boolean_check() (
   local value="${1}"
   shopt -s nocasematch
 
-  # return immediately (and successfully) unless the value is explicitly set to true
+  # return immediately (and successfully) if the value is explicitly set to true
   if [[ ${value} =~ ^(true|1)$ ]]; then
     return 0
   fi

--- a/hooks/command
+++ b/hooks/command
@@ -1,20 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
+
+if [[ ${BASH_VERSINFO[0]} -le 3 ]]; then
+  echo "unable to continue, Bash 4 or newer required" 1>&2
+  exit 1
+fi
+
+shopt -s globstar extglob
 
 # Reads either a value or a list from plugin config
 function plugin_read_list() {
   local prefix="BUILDKITE_PLUGIN_SHELLCHECK_$1"
   local parameter="${prefix}_0"
 
-  if [[ -n "${!parameter:-}" ]]; then
+  if [[ -n ${!parameter:-} ]]; then
     local i=0
     local parameter="${prefix}_${i}"
-    while [[ -n "${!parameter:-}" ]]; do
+    while [[ -n ${!parameter:-} ]]; do
       echo "${!parameter}"
-      i=$((i+1))
+      i=$((i + 1))
       parameter="${prefix}_${i}"
     done
-  elif [[ -n "${!prefix:-}" ]]; then
+  elif [[ -n ${!prefix:-} ]]; then
     echo "${!prefix}"
   fi
 }
@@ -23,13 +30,13 @@ IFS=$'\n\t'
 files=()
 
 # Evaluate all the globs and return the files that exist
-for file in $(plugin_read_list FILES) ; do
-  if [[ -e $file ]] ; then
+for file in $(plugin_read_list FILES); do
+  if [[ -e $file ]]; then
     files+=("$file")
   fi
 done
 
-if [[ -z ${files:-} ]] ; then
+if [[ -z ${files:-} ]]; then
   echo "No files found to shellcheck"
   exit 1
 fi
@@ -38,14 +45,14 @@ fi
 # for pretty online log display (but someone can override this with an
 # explicit `options: "--color=never"`)
 options=("--color=always")
-while IFS=$'\n' read -r option ; do
+while IFS=$'\n' read -r option; do
   options+=("$option")
 done < <(plugin_read_list OPTIONS)
 
 BUILDKITE_PLUGIN_SHELLCHECK_VERSION="${BUILDKITE_PLUGIN_SHELLCHECK_VERSION:-stable}"
 
 echo "+++ Running shellcheck on ${#files[@]} files"
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "koalaman/shellcheck:$BUILDKITE_PLUGIN_SHELLCHECK_VERSION" "${options[@]+${options[@]}}" "${files[@]}" ; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "koalaman/shellcheck:$BUILDKITE_PLUGIN_SHELLCHECK_VERSION" "${options[@]+${options[@]}}" "${files[@]}"; then
   echo "Files are ok ✅"
 else
   exit 1

--- a/hooks/command
+++ b/hooks/command
@@ -14,7 +14,7 @@ set_shopt() {
   local varname
   varname="$(tr '[:lower:]' '[:upper:]' <<< "BUILDKITE_PLUGIN_SHELLCHECK_${option}")"
 
-  if [[ -n ${!varname:-} ]]; then
+  if [[ ${!varname:-0} -eq 1 ]]; then
     bash_version_check "${option}"
     shopt -s "${option}"
   fi

--- a/hooks/command
+++ b/hooks/command
@@ -6,24 +6,24 @@ fail() {
   exit 1
 }
 
-# checks if a buildkite variable corresponding to a given shopt is set,
-# and then attempts to set it. Errors will be caught and pushed up through
+# `boolean_check()` runs in a subshell to keep the use
+# of `shopt` constrained from the rest of the script.
+boolean_check() (
+  local value="${1}"
+  shopt -s nocasematch
+
+  # return immediately (and successfully) unless the value is explicitly set to true
+  if [[ ${value} =~ ^(true|1)$ ]]; then
+    return 0
+  fi
+
+  return 1
+)
+
+# Attempts to set a given shopt. Errors will be caught and pushed up through
 # error logging along with a note about the required Bash version number.
 set_shopt() {
   local option="${1}"
-
-  # `tr` is used instead of Bash 4's ^^ (uppercase) and ,, (lowercase)
-  # because evaluating which version of Bash the agent is running only
-  # happens when setting `shopt` values; it leads to clunkier, more
-  # verbose assignments but it should ensure wider compatability in situations
-  # where no `shopt` values need to be set at all.
-  local varname
-  varname="$(tr '[:lower:]' '[:upper:]' <<< "BUILDKITE_PLUGIN_SHELLCHECK_${option}")"
-  local value
-  value="$(tr '[:upper:]' '[:lower:]' <<< "${!varname:-false}")"
-
-  # return immediately (and successfully) unless the value is explicitly set to true
-  [[ ${value} =~ ^(true|1)$ ]] || return 0
 
   # macOS is the last major platform still using Bash 3, and `shopt -q` is
   # broken on macOS. So we have to mute `shopt` the old-fashioned way
@@ -67,8 +67,16 @@ plugin_read_list() {
   fi
 }
 
-set_shopt globstar
-set_shopt extglob
+# Evaluate whether or not the glob behavior modifiers are enabled, and
+# attempt to set the corresponding shopts for them.
+echo "~~~ Checking for glob behavior modifiers"
+if boolean_check "${BUILDKITE_PLUGIN_SHELLCHECK_RECURSIVE_GLOB:-false}"; then
+  set_shopt globstar && echo "Recursive globbing enabled"
+fi
+
+if boolean_check "${BUILDKITE_PLUGIN_SHELLCHECK_EXTENDED_GLOB:-false}"; then
+  set_shopt extglob && echo "Extended globbing enabled"
+fi
 
 IFS=$'\n\t'
 files=()

--- a/hooks/command
+++ b/hooks/command
@@ -25,15 +25,9 @@ bash_version_check() {
   local required
 
   case "${option}" in
-    autocd | checkjobs | compat32 | compat40 | compat41 | compat42 | compat43 | complete_fullquote | direxpand | dirspell | globasciiranges | globstar | inherit_errexit | lastpipe)
-      required="4"
-      ;;
-    assoc_expand_once | compat44 | localvar_inherit | localvar_unset | progcomp_alias)
-      required="5"
-      ;;
-    *)
-      required="3"
-      ;;
+    globstar) required="4" ;;
+    extglob) required="3" ;;
+    *)  fail "attempted to set unknown shopt '${option}'" ;;
   esac
 
   if [[ ${BASH_VERSINFO[0]} -lt ${required} ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -27,8 +27,8 @@ set_shopt() {
 
   # macOS is the last major platform still using Bash 3, and `shopt -q` is
   # broken on macOS. So we have to mute `shopt` the old-fashioned way
-  # and redirect output to /dev/null. Since the list of options's we'll attempt
-  # to set is so constrained, we can use a small helper fuction to look up
+  # and redirect output to /dev/null. Since the list of options that we'll
+  # attempt to set is so constrained, we can use a small helper fuction to look up
   # which version of bash introduced a given the shopts in our error handling.
   if ! shopt -s "${option}" &> /dev/null; then
     fail "failed to set shopt '${option}: $(bash_version_lookup "${option}")"

--- a/hooks/command
+++ b/hooks/command
@@ -14,7 +14,7 @@ set_shopt() {
   local varname
   varname="$(tr '[:lower:]' '[:upper:]' <<< "BUILDKITE_PLUGIN_SHELLCHECK_${option}")"
 
-  if [[ ${!varname:-0} -eq 1 ]]; then
+  if [[ ${!varname:-false} == true ]]; then
     bash_version_check "${option}"
     shopt -s "${option}"
   fi

--- a/hooks/command
+++ b/hooks/command
@@ -1,15 +1,48 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -eu -o pipefail
 
-if [[ ${BASH_VERSINFO[0]} -le 3 ]]; then
-  echo "unable to continue, Bash 4 or newer required" 1>&2
+fail() {
+  echo "ERROR: ${*}" 1>&2
   exit 1
-fi
+}
 
-shopt -s globstar extglob
+# checks if a corresponding buildkite variable is set,
+# and then if the shell is new enough to support that
+# particular shopt.
+set_shopt() {
+  local option="${1}"
+  local varname
+  varname="$(tr '[:lower:]' '[:upper:]' <<< "BUILDKITE_PLUGIN_SHELLCHECK_${option}")"
+
+  if [[ -n ${!varname:-} ]]; then
+    bash_version_check "${option}"
+    shopt -s "${option}"
+  fi
+}
+
+bash_version_check() {
+  local option="${1}"
+  local required
+
+  case "${option}" in
+    autocd | checkjobs | compat32 | compat40 | compat41 | compat42 | compat43 | complete_fullquote | direxpand | dirspell | globasciiranges | globstar | inherit_errexit | lastpipe)
+      required="4"
+      ;;
+    assoc_expand_once | compat44 | localvar_inherit | localvar_unset | progcomp_alias)
+      required="5"
+      ;;
+    *)
+      required="3"
+      ;;
+  esac
+
+  if [[ ${BASH_VERSINFO[0]} -lt ${required} ]]; then
+    fail "shopt '${option}' requires Bash ${required} or newer"
+  fi
+}
 
 # Reads either a value or a list from plugin config
-function plugin_read_list() {
+plugin_read_list() {
   local prefix="BUILDKITE_PLUGIN_SHELLCHECK_$1"
   local parameter="${prefix}_0"
 
@@ -25,6 +58,9 @@ function plugin_read_list() {
     echo "${!prefix}"
   fi
 }
+
+set_shopt globstar
+set_shopt extglob
 
 IFS=$'\n\t'
 files=()

--- a/hooks/command
+++ b/hooks/command
@@ -11,10 +11,18 @@ fail() {
 # particular shopt.
 set_shopt() {
   local option="${1}"
+
+  # `tr` is used instead of Bash 4's ^^ (uppercase) and ,, (lowercase)
+  # because evaluating which version of Bash the agent is running only
+  # happens when setting `shopt` values; it leads to clunkier, more
+  # verbose assignments but it should ensure wider compatability in situations
+  # where no `shopt` values need to be set at all.
   local varname
   varname="$(tr '[:lower:]' '[:upper:]' <<< "BUILDKITE_PLUGIN_SHELLCHECK_${option}")"
+  local value
+  value="$(tr '[:upper:]' '[:lower:]' <<< "${!varname:-false}")"
 
-  if [[ ${!varname:-false} == true ]]; then
+  if [[ ${value} =~ ^(true|1)$ ]]; then
     bash_version_check "${option}"
     shopt -s "${option}"
   fi

--- a/hooks/command
+++ b/hooks/command
@@ -6,9 +6,9 @@ fail() {
   exit 1
 }
 
-# checks if a corresponding buildkite variable is set,
-# and then if the shell is new enough to support that
-# particular shopt.
+# checks if a buildkite variable corresponding to a given shopt is set,
+# and then attempts to set it. Errors will be caught and pushed up through
+# error logging along with a note about the required Bash version number.
 set_shopt() {
   local option="${1}"
 
@@ -22,25 +22,31 @@ set_shopt() {
   local value
   value="$(tr '[:upper:]' '[:lower:]' <<< "${!varname:-false}")"
 
-  if [[ ${value} =~ ^(true|1)$ ]]; then
-    bash_version_check "${option}"
-    shopt -s "${option}"
+  # return immediately (and successfully) unless the value is explicitly set to true
+  [[ ${value} =~ ^(true|1)$ ]] || return 0
+
+  # macOS is the last major platform still using Bash 3, and `shopt -q` is
+  # broken on macOS. So we have to mute `shopt` the old-fashioned way
+  # and redirect output to /dev/null. Since the list of options's we'll attempt
+  # to set is so constrained, we can use a small helper fuction to look up
+  # which version of bash introduced a given the shopts in our error handling.
+  if ! shopt -s "${option}" &> /dev/null; then
+    fail "failed to set shopt '${option}: $(bash_version_lookup "${option}")"
   fi
 }
 
-bash_version_check() {
+# look up which version of bash introduced
+# a given shopt and print it to stdout.
+bash_version_lookup() {
   local option="${1}"
   local required
 
   case "${option}" in
     globstar) required="4" ;;
-    extglob) required="3" ;;
-    *)  fail "attempted to set unknown shopt '${option}'" ;;
+    extglob) required="2" ;;
   esac
 
-  if [[ ${BASH_VERSINFO[0]} -lt ${required} ]]; then
-    fail "shopt '${option}' requires Bash ${required} or newer"
-  fi
+  echo "shopt '${option}' requires Bash ${required} or newer"
 }
 
 # Reads either a value or a list from plugin config

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,10 @@ requirements:
   - docker
 configuration:
   properties:
+    globstar:
+      type: boolean
+    extglob:
+      type: boolean
     files:
       type: [string, array]
       minItems: 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,10 +6,10 @@ requirements:
   - docker
 configuration:
   properties:
-    globstar:
+    recursive_glob:
       type: boolean
       default: false
-    extglob:
+    extended_glob:
       type: boolean
       default: false
     files:

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,8 +8,10 @@ configuration:
   properties:
     globstar:
       type: boolean
+      default: false
     extglob:
       type: boolean
+      default: false
     files:
       type: [string, array]
       minItems: 1

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -36,7 +36,7 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Shellcheck multiple files using recursive globbing enabled with '1'" {
+@test "Shellcheck multiple files using recursive globbing enabled with 'true'" {
   export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=true
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -52,7 +52,7 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Shellcheck multiple files using extended globbing enabled with 'true'" {
+@test "Shellcheck multiple files using extended globbing enabled with '1'" {
   export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=1
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -36,6 +36,21 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
+@test "Shellcheck multiple files with starglob" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="**/*.sh"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/recursive/subdir/stub.sh tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh\"' : echo testing stub.sh test.sh llamas.sh shell with space.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Running shellcheck on 4 files"
+  assert_output --partial "testing stub.sh test.sh llamas.sh shell with space.sh"
+
+  unstub docker
+}
+
 @test "Shellcheck a single file with single option" {
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/subdir/llamas.sh"
   export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_0="--exclude=SC2086"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -37,7 +37,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Shellcheck multiple files using recursive globbing enabled with 'true'" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=true
+  export BUILDKITE_PLUGIN_SHELLCHECK_RECURSIVE_GLOB=true
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
   stub docker \
@@ -53,7 +53,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Shellcheck multiple files using extended globbing enabled with '1'" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=1
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTENDED_GLOB=1
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   stub docker \
@@ -68,8 +68,8 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Recursive globbing fails if starglob is disabled with 'false'" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=false
+@test "Recursive globbing fails if recursive globbing is disabled with 'false'" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_RECURSIVE_GLOB=false
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
   run "$PWD/hooks/command"
@@ -79,7 +79,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Extended globbing fails if extended globbing is disabled with 'FALSE'" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=FALSE
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTENDED_GLOB=FALSE
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   run "$PWD/hooks/command"
@@ -89,13 +89,30 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Extended globbing fails if extended globbing is disabled with '0'" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=0
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTENDED_GLOB=0
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   run "$PWD/hooks/command"
 
   assert_failure
   assert_output --partial "No files found to shellcheck"
+}
+
+@test "Shellcheck multiple files using recursive and extended globbing enabled with 'true'" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_RECURSIVE_GLOB=true
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTENDED_GLOB=true
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.+(sh|bash)"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/recursive/subdir/stub.bash tests/testdata/subdir/stub.bash tests/testdata/recursive/subdir/stub.sh tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh\"' : echo testing stub.sh test.sh llamas.sh shell with space.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Running shellcheck on 6 files"
+  assert_output --partial "testing stub.sh test.sh llamas.sh shell with space.sh"
+
+  unstub docker
 }
 
 @test "Shellcheck a single file with single option" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -36,7 +36,7 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Shellcheck multiple files using recursive globbing" {
+@test "Shellcheck multiple files using recursive globbing enabled with '1'" {
   export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=true
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
@@ -52,18 +52,8 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Recursive globbing fails if starglob is disabled" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=false
-  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "No files found to shellcheck"
-}
-
-@test "Shellcheck multiple files using extended globbing" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=true
+@test "Shellcheck multiple files using extended globbing enabled with 'true'" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=1
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   stub docker \
@@ -78,8 +68,28 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Extended globbing fails if extended globbing is disabled" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=false
+@test "Recursive globbing fails if starglob is disabled with 'false'" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=false
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "No files found to shellcheck"
+}
+
+@test "Extended globbing fails if extended globbing is disabled with 'FALSE'" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=FALSE
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "No files found to shellcheck"
+}
+
+@test "Extended globbing fails if extended globbing is disabled with '0'" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=0
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   run "$PWD/hooks/command"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -37,7 +37,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Shellcheck multiple files using recursive globbing" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=1
+  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=true
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
   stub docker \
@@ -53,7 +53,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Recursive globbing fails if starglob is disabled" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=0
+  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=false
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
   run "$PWD/hooks/command"
@@ -63,7 +63,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Shellcheck multiple files using extended globbing" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=1
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=true
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   stub docker \
@@ -79,7 +79,7 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Extended globbing fails if extended globbing is disabled" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=0
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=false
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   run "$PWD/hooks/command"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -36,7 +36,7 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Shellcheck multiple files with starglob" {
+@test "Shellcheck multiple files using recursive globbing" {
   export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=1
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
@@ -52,7 +52,17 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Shellcheck multiple files with extglob" {
+@test "Recursive globbing fails if starglob is disabled" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=0
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "No files found to shellcheck"
+}
+
+@test "Shellcheck multiple files using extended globbing" {
   export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=1
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
@@ -66,6 +76,16 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "testing llamas.sh shell with space.sh stub.bash"
 
   unstub docker
+}
+
+@test "Extended globbing fails if extended globbing is disabled" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=0
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "No files found to shellcheck"
 }
 
 @test "Shellcheck a single file with single option" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -21,7 +21,7 @@ load '/usr/local/lib/bats/load.bash'
 
 @test "Shellcheck multiple files" {
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/test.sh"
-  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_1="tests/testdata/subdir/*"
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_1="tests/testdata/subdir/*.sh"
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_2="missing"
 
   stub docker \
@@ -37,7 +37,8 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Shellcheck multiple files with starglob" {
-  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="**/*.sh"
+  export BUILDKITE_PLUGIN_SHELLCHECK_GLOBSTAR=1
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
   stub docker \
     "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/recursive/subdir/stub.sh tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh\"' : echo testing stub.sh test.sh llamas.sh shell with space.sh"
@@ -47,6 +48,22 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
   assert_output --partial "Running shellcheck on 4 files"
   assert_output --partial "testing stub.sh test.sh llamas.sh shell with space.sh"
+
+  unstub docker
+}
+
+@test "Shellcheck multiple files with extglob" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_EXTGLOB=1
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh tests/testdata/subdir/stub.bash\"' : echo testing llamas.sh shell with space.sh stub.bash"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Running shellcheck on 3 files"
+  assert_output --partial "testing llamas.sh shell with space.sh stub.bash"
 
   unstub docker
 }
@@ -87,7 +104,7 @@ load '/usr/local/lib/bats/load.bash'
 
 @test "Shellcheck multiple files with multiple options" {
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/test.sh"
-  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_1="tests/testdata/subdir/*"
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_1="tests/testdata/subdir/*.sh"
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_2="missing"
   export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_0="--exclude=SC2086"
   export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_1="--format=gcc"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -41,7 +41,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.sh"
 
   stub docker \
-    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/recursive/subdir/stub.sh tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh\"' : echo testing stub.sh test.sh llamas.sh shell with space.sh"
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/recursive/subdir/stub.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell\ with\ a\ space.sh tests/testdata/test.sh : echo testing stub.sh test.sh llamas.sh shell with space.sh"
 
   run "$PWD/hooks/command"
 
@@ -57,7 +57,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="tests/testdata/subdir/*.+(sh|bash)"
 
   stub docker \
-    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh tests/testdata/subdir/stub.bash\"' : echo testing llamas.sh shell with space.sh stub.bash"
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell\ with\ a\ space.sh tests/testdata/subdir/stub.bash : echo testing llamas.sh shell with space.sh stub.bash"
 
   run "$PWD/hooks/command"
 
@@ -104,7 +104,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES="**/*.+(sh|bash)"
 
   stub docker \
-    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/recursive/subdir/stub.bash tests/testdata/subdir/stub.bash tests/testdata/recursive/subdir/stub.sh tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh\"' : echo testing stub.sh test.sh llamas.sh shell with space.sh"
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/recursive/subdir/stub.bash tests/testdata/recursive/subdir/stub.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell\ with\ a\ space.sh tests/testdata/subdir/stub.bash tests/testdata/test.sh : echo testing stub.sh test.sh llamas.sh shell with space.sh"
 
   run "$PWD/hooks/command"
 

--- a/tests/testdata/recursive/subdir/stub.bash
+++ b/tests/testdata/recursive/subdir/stub.bash
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo halb

--- a/tests/testdata/recursive/subdir/stub.sh
+++ b/tests/testdata/recursive/subdir/stub.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo blah blah blah

--- a/tests/testdata/subdir/stub.bash
+++ b/tests/testdata/subdir/stub.bash
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo blah blah blah


### PR DESCRIPTION
Ran into #35, and recursion would be extremely useful for my org. So I've added it.
I figure that `extglob` and `globstar` are pretty safe shopts since Bash 4 came out in 2009, but I've left some "safety valves" to ensure that we don't try to set those options against Bash 3 if we run into it.

Oh, I also ran `shfmt` and `shellcheck` against my work, so if there's little bits of whitespace drift those were introduced by tooling and they're safe.