### PR TITLE
Fix tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: run bats tests
     plugins:
-      - docker-compose#v3.9.0:
+      - docker-compose#v3.13.0:
           run: tests
 
   - label: run shellcheck

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
       - .:/plugin

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ],
   "docker-compose": {
     "digest": {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -15,6 +15,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
   assert_output --partial "Running shellcheck on 1 files"
   assert_output --partial "testing test.sh"
+  assert_output --partial "Files are ok"
 
   unstub docker
 }
@@ -32,6 +33,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
   assert_output --partial "Running shellcheck on 3 files"
   assert_output --partial "testing test.sh llamas.sh shell with space.sh"
+  assert_output --partial "Files are ok"
 
   unstub docker
 }
@@ -48,6 +50,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
   assert_output --partial "Running shellcheck on 1 files"
   assert_output --partial "testing llamas.sh"
+  assert_output --partial "Files are ok"
 
   unstub docker
 }
@@ -66,6 +69,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
   assert_output --partial "Running shellcheck on 1 files"
   assert_output --partial "testing llamas.sh"
+  assert_output --partial "Files are ok"
 
   unstub docker
 }
@@ -86,6 +90,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
   assert_output --partial "Running shellcheck on 3 files"
   assert_output --partial "testing test.sh llamas.sh shell with space.sh"
+  assert_output --partial "Files are ok"
 
   unstub docker
 }
@@ -98,9 +103,10 @@ load '/usr/local/lib/bats/load.bash'
 
   run "$PWD/hooks/command"
 
-  assert_failure
+  assert_failure 1
   assert_output --partial "Running shellcheck on 1 files"
   assert_output --partial "shellcheck failed"
+  refute_output --partial "Files are ok"
 
   unstub docker
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -25,7 +25,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_2="missing"
 
   stub docker \
-    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always \"tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh\"' : echo testing test.sh llamas.sh shell with space.sh"
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell\ with\ a\ space.sh : echo testing test.sh llamas.sh shell with space.sh"
 
   run "$PWD/hooks/command"
 
@@ -79,7 +79,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SHELLCHECK_OPTIONS_2="-x"
 
   stub docker \
-    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always --exclude=SC2086 --format=gcc -x \"tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell with space.sh\"' : echo testing test.sh llamas.sh shell with space.sh"
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always --exclude=SC2086 --format=gcc -x tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell\ with\ a\ space.sh : echo testing test.sh llamas.sh shell with space.sh"
 
   run "$PWD/hooks/command"
 
@@ -94,7 +94,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/subdir/llamas.sh"
 
   stub docker \
-    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/test.sh tests/testdata/subdir/llamas.sh tests/testdata/subdir/shell\ with\ space.sh' : echo shellcheck failed; exit 1"
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/subdir/llamas.sh : echo shellcheck failed; exit 1"
 
   run "$PWD/hooks/command"
 


### PR DESCRIPTION
Fixes tests that have been failing since the latest release of the `plugin-tester` image.

Also pinned the version of the image to avoid major upgrades to break this unintentionally.

While I was at it:
* included docker compose plugin update (same as #43)
* deactivated the dependency dasboard #37 