### PR TITLE
enable image configuration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,9 +15,18 @@ steps:
       - plugin-linter#v3.3.0:
           id: shellcheck
 
+  - label: selftest - fork
+    plugins:
+      - ${BUILDKITE_PULL_REQUEST_REPO}#${BUILDKITE_COMMIT}:
+          files:
+            - hooks/*
+            - buildkite/*.sh
+    if: build.pull_request.repository.fork == true
+
   - label: selftest
     plugins:
       - shellcheck#${BUILDKITE_COMMIT}:
           files:
             - hooks/*
             - buildkite/*.sh
+    if: build.pull_request.repository.fork == false

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Which shell check image to use.
 
 Default: `koalaman/shellcheck`
 
+## Developing
+
+To run the tests:
+
+```bash
+docker-compose run --rm tests bats tests
+```
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Version of docker image to use.
 
 Default: `latest`
 
-## `image` (string)
+### `image` (string)
 
 Which shell check image to use.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Version of docker image to use.
 
 Default: `latest`
 
+## `image` (string)
+
+Which shell check image to use.
+
+Default: `koalaman/shellcheck`
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,5 @@
+services:
+  tests:
+    image: buildkite/plugin-tester:v4.1.1
+    volumes:
+      - ".:/plugin"

--- a/hooks/command
+++ b/hooks/command
@@ -102,9 +102,10 @@ while IFS=$'\n' read -r option; do
 done < <(plugin_read_list OPTIONS)
 
 BUILDKITE_PLUGIN_SHELLCHECK_VERSION="${BUILDKITE_PLUGIN_SHELLCHECK_VERSION:-stable}"
+BUILDKITE_PLUGIN_SHELLCHECK_IMAGE="${BUILDKITE_PLUGIN_SHELLCHECK_IMAGE:-koalaman/shellcheck}"
 
 echo "+++ Running shellcheck on ${#files[@]} files"
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "koalaman/shellcheck:$BUILDKITE_PLUGIN_SHELLCHECK_VERSION" "${options[@]+${options[@]}}" "${files[@]}"; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "$BUILDKITE_PLUGIN_SHELLCHECK_IMAGE:$BUILDKITE_PLUGIN_SHELLCHECK_VERSION" "${options[@]+${options[@]}}" "${files[@]}"; then
   echo "Files are ok ✅"
 else
   exit 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,5 +20,7 @@ configuration:
       minItems: 1
     version:
       type: [string]
+    image:
+      type: [string]
   required:
     - files

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -189,3 +189,39 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
   unstub docker
 }
+
+@test "Shellcheck uses default image when not specified" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/test.sh"
+  unset BUILDKITE_PLUGIN_SHELLCHECK_IMAGE
+  unset BUILDKITE_PLUGIN_SHELLCHECK_VERSION
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/test.sh : echo running shellcheck on test.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Running shellcheck on 1 files"
+  assert_output --partial "running shellcheck on test.sh"
+  assert_output --partial "Files are ok"
+
+  unstub docker
+}
+
+@test "Shellcheck uses default image when specified" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/test.sh"
+  export BUILDKITE_PLUGIN_SHELLCHECK_IMAGE="foo/shellcheck"
+  export BUILDKITE_PLUGIN_SHELLCHECK_VERSION="bar"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt foo/shellcheck:bar --color=always tests/testdata/test.sh : echo running shellcheck on test.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Running shellcheck on 1 files"
+  assert_output --partial "running shellcheck on test.sh"
+  assert_output --partial "Files are ok"
+
+  unstub docker
+}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -225,3 +225,22 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
   unstub docker
 }
+
+
+@test "Shellcheck uses default image when empty string set" {
+  export BUILDKITE_PLUGIN_SHELLCHECK_FILES_0="tests/testdata/test.sh"
+  export BUILDKITE_PLUGIN_SHELLCHECK_IMAGE=""
+  export BUILDKITE_PLUGIN_SHELLCHECK_VERSION="stable"
+
+  stub docker \
+    "run --rm -v $PWD:/mnt --workdir /mnt koalaman/shellcheck:stable --color=always tests/testdata/test.sh : echo running shellcheck on test.sh"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Running shellcheck on 1 files"
+  assert_output --partial "running shellcheck on test.sh"
+  assert_output --partial "Files are ok"
+
+  unstub docker
+}


### PR DESCRIPTION
# Overview

This PR adds optional configuration for the base `shellcheck` image.

## Rationale

Our organization prefers to store docker images in an internal registry, by enabling this configuration
option, we can continue to use the plugin with our specified registry
