### PR TITLE
Updated README to reference `v1.4.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This will check all shellscripts with shellcheck.
 ```yml
 steps:
   - plugins:
-      - shellcheck#v1.3.0:
+      - shellcheck#v1.4.0:
           files: scripts/*.sh
 ```
 


### PR DESCRIPTION
Linter is being unhappy in #58 given this plugin's README references `v1.3.0`

Bumper to `v1.4.0` for that to get a green status 👍 